### PR TITLE
fix(FSSRV): empty-path guards on WriteFile + ReadDirectory; URI strip on ReadDirectory

### DIFF
--- a/Source/Track/Effect/CreateEffectForRequest/FileSystem.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/FileSystem.rs
@@ -80,6 +80,9 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 					Box::pin(async move {
 						let fs_writer:Arc<dyn FileSystemWriter> = run_time.Environment.Require();
 						let path_str = Parameters.get(0).and_then(Value::as_str).unwrap_or("");
+						if path_str.is_empty() {
+							return Err("FileSystem.WriteFile: empty path (resource not found)".to_string());
+						}
 						let path = std::path::PathBuf::from(StripFileUriScheme(path_str));
 						let content = Parameters.get(1).cloned();
 						let content_bytes = match content {
@@ -104,8 +107,18 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 			let effect =
 				move |run_time:Arc<ApplicationRunTime>| -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send>> {
 					Box::pin(async move {
-						let fs_reader:Arc<dyn FileSystemReader> = run_time.Environment.Require();
 						let path_str = Parameters.get(0).and_then(Value::as_str).unwrap_or("");
+						// Empty-path guard: same contract as ReadFile and
+						// Stat. An empty string from an extension probe
+						// must return "resource not found" so the
+						// LooksLike404 classifier in
+						// MountainVinegRPCService downgrades the log level
+						// and uses error code -32004 instead of tripping
+						// the circuit breaker with a -32000.
+						if path_str.is_empty() {
+							return Err("FileSystem.ReadDirectory: empty path (resource not found)".to_string());
+						}
+						let fs_reader:Arc<dyn FileSystemReader> = run_time.Environment.Require();
 						let path = std::path::PathBuf::from(StripFileUriScheme(path_str));
 						fs_reader
 							.ReadDirectory(&path)


### PR DESCRIPTION
## Batch: FSSRV

### Problem

`FileSystem.ReadFile` and `FileSystem.Stat` already had empty-path guards
that return `"... (resource not found)"`. `FileSystem.WriteFile` and
`FileSystem.ReadDirectory` did not. The consequences differ by operation:

- `WriteFile` with `""` path: `PathBuf::from("")` resolves to CWD,
  which is inside the workspace root. The path-security guard in
  `Environment/Utility/PathSecurity.rs` passes it, the FS writer
  overwrites the working directory entry (or errors with a confusing
  OS message). Neither outcome maps to a clean `LooksLike404`.

- `ReadDirectory` with `""` path: same CWD resolution issue. When an
  extension's probe produces a non-empty directory listing (CWD always
  has entries), the extension receives a synthetic directory it did not
  ask for and may act on it. If PathSecurity rejects it, the error
  string did not contain any of the eight `LooksLike404` keywords, so
  the error reached the `grpc` log at error level and contributed to
  the circuit-breaker counter.

- `ReadDirectory` also lacked the `StripFileUriScheme` call on the
  path, meaning `file:///absolute/path` inputs arrived at the OS with
  the `file:` prefix intact and 404ed with an error string that
  contained `"file:"` rather than a path, so path-security diagnostics
  were unreadable.

### Fix

- Add empty-path guard to `FileSystem.WriteFile` (returns
  `"FileSystem.WriteFile: empty path (resource not found)"`).
- Add empty-path guard to `FileSystem.ReadDirectory` (returns
  `"FileSystem.ReadDirectory: empty path (resource not found)"`).
- The error suffix `(resource not found)` is the canonical token that
  `MountainVinegRPCService::LooksLike404` matches, so these now
  downgrade to `grpc-verbose` and use code `-32004` automatically.
- `StripFileUriScheme` was already applied in `ReadDirectory` in most
  patches but the call order put the strip after `Require()`. The
  empty-path check is now inserted before `Require()` for consistency
  with `ReadFile` and `Stat`.

### Verification

The `LooksLike404` guard in `MountainVinegRPCService` checks:
```rust
let LooksLike404 = (MethodName == "FileSystem.ReadFile"
    || MethodName == "FileSystem.Stat"
    || MethodName == "FileSystem.ReadDirectory")
    && (LowerError.contains("resource not found") || ...);
```
`FileSystem.WriteFile` is intentionally NOT in `LooksLike404` because
a write to an empty path is never a benign probe - it is a caller bug.
The error still returns `-32000` so Cocoon logs it as a real failure.