### PR TITLE
fix(TVIEW): wire tree.unregister + tree.dispose to provider; emit TreeViewDispose

### DIFF
--- a/Source/Track/Effect/CreateEffectForRequest/TreeView.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/TreeView.rs
@@ -129,12 +129,65 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 
 		"tree.unregister" | "tree.dispose" => {
 			let effect =
-				move |_run_time:Arc<ApplicationRunTime>| -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send>> {
-
+				move |run_time:Arc<ApplicationRunTime>| -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send>> {
 					Box::pin(async move {
-						let handle = Parameters.get(0).and_then(Value::as_str).unwrap_or("");
-						dev_log!("ipc", "[tree.unregister] handle={}", handle);
-						Ok(json!(null))
+						let view_id = Parameters
+							.get(0)
+							.and_then(Value::as_str)
+							.unwrap_or("")
+							.to_string();
+						dev_log!(
+							"tree-view",
+							"[TreeView] unregister view={}",
+							view_id
+						);
+						if view_id.is_empty() {
+							dev_log!(
+								"tree-view",
+								"[TreeView] unregister skipped: empty view_id"
+							);
+							return Ok(json!(null));
+						}
+						let provider:Arc<dyn TreeViewProvider> = run_time.Environment.Require();
+						let Result = provider.UnregisterTreeDataProvider(view_id.clone()).await;
+						dev_log!(
+							"tree-view",
+							"[TreeView] unregister result={} view={}",
+							if Result.is_ok() { "ok" } else { "err" },
+							view_id
+						);
+						// Emit TreeViewDispose so Sky's
+						// `_dataProvider` slot is cleared on the
+						// renderer side. Without this emit, Sky keeps
+						// the stale provider reference alive and
+						// `getChildren` continues to hit it after
+						// the extension has disposed the registration.
+						if Result.is_ok() {
+							match LogSkyEmit(
+								&run_time.Environment.ApplicationHandle,
+								SkyEvent::TreeViewDispose.AsStr(),
+								json!({ "viewId": view_id }),
+							) {
+								Ok(()) => {
+									dev_log!(
+										"tree-view",
+										"[TreeView] dispose-emit-ok channel={} view={}",
+										SkyEvent::TreeViewDispose.AsStr(),
+										view_id
+									);
+								},
+								Err(Error) => {
+									dev_log!(
+										"grpc",
+										"warn: [LandFix:Tree] failed to emit {} for view={}: {}",
+										SkyEvent::TreeViewDispose.AsStr(),
+										view_id,
+										Error
+									);
+								},
+							}
+						}
+						Result.map(|_| json!(null)).map_err(|e| e.to_string())
 					})
 				};
 


### PR DESCRIPTION
## Batch: TVIEW

### Problem

`tree.unregister` / `tree.dispose` were stub effects. The body logged
`handle` from `Parameters.get(0)` but never called the provider and
never emitted a `SkyEvent`.

Consequences:

1. `TreeViewProvider::UnregisterTreeDataProvider` was never called.
   Sky's `ITreeView` instance retained the `_dataProvider` reference
   after the extension called `.dispose()`. A subsequent
   `registerTreeDataProvider` on the same view ID from the same
   extension (e.g., on reload or update) triggered a duplicate
   registration warning from `Sky/Source/TreeView/TreeViewService.ts`;
   the new provider was silently ignored and the tree stayed stale.

2. `SkyEvent::TreeViewDispose` was never emitted. The renderer side
   had no way to know the provider slot was vacated. `getChildren()`
   continued hitting the old provider pointer, returning stale data
   or causing a panic if the Cocoon-side object had been GC'd.

3. The existing variable name was `handle` (matching the wrong
   naming convention from the webview arm); the TreeView protocol
   identifies views by `view_id`, not by a webview handle.

### Fix

- Read `view_id` from `Parameters.get(0)` (matching the register arm).
- Short-circuit with an early `Ok(json!(null))` if `view_id` is empty,
  logging under `tree-view` for diagnostic parity.
- Call `provider.UnregisterTreeDataProvider(view_id.clone()).await`.
- On `Ok`, emit `SkyEvent::TreeViewDispose` via `LogSkyEmit` with
  `{ "viewId": view_id }`, matching the register arm's payload shape.
- Log all four outcomes (`unregister ok/err`, `emit ok/err`) under
  both `tree-view` and `grpc` tags.

### Dependency

`SkyEvent::TreeViewDispose` must exist in
`Common/Source/IPC/SkyEvent.rs`. If it has not yet been added, add:
```rust
TreeViewDispose => "sky://tree-view/dispose",
```
and ensure the Sky-side listener is registered on that channel.