### PR TITLE
fix(CFGUP): add side-effect error logging parity to config.update

### DIFF
--- a/Source/Track/Effect/CreateEffectForRequest/Configuration.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/Configuration.rs
@@ -73,15 +73,28 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 								"affected": [KeyForEvents.clone()],
 							});
 							let AppHandle = run_time.Environment.ApplicationHandle.clone();
-							let _ = AppHandle.emit("sky://configuration/changed", Payload.clone());
+							if let Err(Error) = AppHandle.emit("sky://configuration/changed", Payload.clone()) {
+								dev_log!(
+									"config",
+									"warn: [config.update] sky://configuration/changed emit failed: {}",
+									Error
+								);
+							}
 							let IPCProvider:Arc<dyn IPCProviderTrait> = run_time.Environment.Require();
-							let _ = IPCProvider
+							if let Err(Error) = IPCProvider
 								.SendNotificationToSideCar(
 									"cocoon-main".to_string(),
 									"configuration.change".to_string(),
 									Payload,
 								)
-								.await;
+								.await
+							{
+								dev_log!(
+									"config",
+									"warn: [config.update] Cocoon configuration.change notification failed: {}",
+									Error
+								);
+							}
 						}
 						result.map(|_| json!(null)).map_err(|e| e.to_string())
 					})


### PR DESCRIPTION
`config.update` and `Configuration.Update` both call `UpdateConfigurationValue`, emit `sky://configuration/changed`, and notify `cocoon-main` with `configuration.change`. Only `Configuration.Update` logs failure of those two side effects. In `config.update`, both operations are silently discarded with `let _ = ...`, making post-update delivery failures invisible even when the underlying configuration write succeeds.

This change adds the same `dev_log!("config", ...)` warning pattern already used by `Configuration.Update` to both side-effect failure paths in `config.update`. No payload shape, ordering, or success semantics are changed.