### PR TITLE
fix(DOCSV+FRALIAS): replace /tmp sentinel fallback and add StripFileUriScheme to legacy aliases

### DIFF
--- a/Source/Track/Effect/CreateEffectForRequest/Documents.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/Documents.rs
@@ -17,7 +17,11 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 					Box::pin(async move {
 						let document_provider:Arc<dyn DocumentProvider> = run_time.Environment.Require();
 						let uri_str = Parameters.get(0).and_then(Value::as_str).unwrap_or("");
-						let uri = Url::parse(uri_str).unwrap_or_else(|_| Url::parse("file:///tmp/test.txt").unwrap());
+						if uri_str.is_empty() {
+							return Err("Document.Save: empty URI (resource not found)".to_string());
+						}
+						let uri = Url::parse(uri_str)
+							.map_err(|e| format!("Document.Save: invalid URI '{}': {}", uri_str, e))?;
 						document_provider
 							.SaveDocument(uri)
 							.await
@@ -35,8 +39,11 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 					Box::pin(async move {
 						let document_provider:Arc<dyn DocumentProvider> = run_time.Environment.Require();
 						let original_uri_str = Parameters.get(0).and_then(Value::as_str).unwrap_or("");
+						if original_uri_str.is_empty() {
+							return Err("Document.SaveAs: empty URI (resource not found)".to_string());
+						}
 						let original_uri = Url::parse(original_uri_str)
-							.unwrap_or_else(|_| Url::parse("file:///tmp/test.txt").unwrap());
+							.map_err(|e| format!("Document.SaveAs: invalid URI '{}': {}", original_uri_str, e))?;
 						let target_uri = Parameters
 							.get(1)
 							.and_then(Value::as_str)

--- a/Source/Track/Effect/CreateEffectForRequest/FileReadAlias.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/FileReadAlias.rs
@@ -13,6 +13,24 @@ use tauri::Runtime;
 
 use crate::{RunTime::ApplicationRunTime::ApplicationRunTime, Track::Effect::MappedEffectType::MappedEffect};
 
+/// Strip a leading `file://` (or `file:///`) scheme from the incoming path.
+/// Mirrors the helper in `FileSystem.rs`; inlined here to avoid a cross-module
+/// dependency on a private function in a sibling module.
+/// Cocoon sends full URIs like `file:///<home>/.land/extensions/...` through
+/// the legacy `openDocument`/`readFile`/`stat` routes; without stripping,
+/// `PathBuf` roots at the literal scheme string and every read 404s.
+fn StripFileUriScheme(Input:&str) -> &str {
+	if let Some(Rest) = Input.strip_prefix("file://") {
+		if Rest.starts_with('/') {
+			return Rest;
+		}
+		if let Some(Idx) = Rest.find('/') {
+			return &Rest[Idx..];
+		}
+	}
+	Input
+}
+
 pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Result<MappedEffect, String>> {
 	match MethodName {
 		"openDocument" | "readFile" | "stat" => {
@@ -32,7 +50,14 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 						} else {
 							Parameters.get(0).and_then(Value::as_str).unwrap_or("").to_string()
 						};
-						let PathBuf_ = std::path::PathBuf::from(&Path);
+						// Empty-path guard: matches the FileSystem.* contract so that
+						// the LooksLike404 classifier in MountainVinegRPCService
+						// downgrades the log level and uses error code -32004 rather
+						// than tripping the circuit breaker with a -32000.
+						if Path.is_empty() {
+							return Err(format!("{}: empty path (resource not found)", MethodNameOwned));
+						}
+						let PathBuf_ = std::path::PathBuf::from(StripFileUriScheme(&Path));
 						match MethodNameOwned.as_str() {
 							"stat" => {
 								fs_reader


### PR DESCRIPTION
## Summary

Two correctness fixes identified during post-merge reinspection, batched together as they are both URI-handling gaps in the `CreateEffectForRequest` layer.

---

## DOCSV — `Documents.rs`

### Problem

`Document.Save` and `Document.SaveAs` fell back to `file:///tmp/test.txt` when the incoming URI was empty or failed `Url::parse`:

```rust
// Before
let uri = Url::parse(uri_str).unwrap_or_else(|_| Url::parse("file:///tmp/test.txt").unwrap());
```

This is the same sentinel bug previously fixed in `Webview.rs` (`$resolveCustomEditor`). A bad or missing URI silently became a valid one pointing at a temp file, so `SaveDocument` / `SaveDocumentAs` operated on the wrong path with no error surfaced to the caller.

### Fix

- Empty URI → `Err("Document.Save: empty URI (resource not found)")`
- Unparseable URI → `Err("Document.Save: invalid URI '...': <parse error>")`
- Matches the pattern used in `Debug.Start` (returns `None` for empty, `Url::parse(...).ok()` for invalid)

---

## FRALIAS — `FileReadAlias.rs`

### Problem

The legacy `openDocument`, `readFile`, and `stat` routes passed the extracted path string directly to `PathBuf::from(...)` without stripping the `file://` scheme:

```rust
// Before
let PathBuf_ = std::path::PathBuf::from(&Path);
```

Cocoon sends full `file:///` URIs through these routes. Without stripping, `PathBuf` roots at the literal string `"file:///..."` and every read 404s — the same class of bug that motivated `StripFileUriScheme` in `FileSystem.rs`. The legacy aliases were not updated at the time.

Also missing: an empty-path guard, so an empty string was passed to `PathBuf::from("")` and then to `StatFile` / `ReadFile`, which could confuse the path-security guard into emitting a `-32000` breaker error instead of the quieter `-32004` not-found code.

### Fix

- Inlined `StripFileUriScheme` (identical to the one in `FileSystem.rs`; inlined rather than shared to avoid a cross-module private-function dependency)
- Applied before `PathBuf::from(...)` in all three alias branches
- Added empty-path guard matching the `FileSystem.*` contract, with error message format `"{method}: empty path (resource not found)"` so `LooksLike404` classifies it correctly

---

## Files changed

| File | Change |
|---|---|
| `Source/Track/Effect/CreateEffectForRequest/Documents.rs` | Replace `/tmp` sentinel with `Err` on empty/invalid URI |
| `Source/Track/Effect/CreateEffectForRequest/FileReadAlias.rs` | Add `StripFileUriScheme` + empty-path guard |