### PR TITLE
fix(SBAR): replace hardcoded identifier sentinels with real parameter extraction

### DIFF
--- a/Source/Track/Effect/CreateEffectForRequest/StatusBar.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/StatusBar.rs
@@ -18,22 +18,75 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 				move |run_time:Arc<ApplicationRunTime>| -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send>> {
 					Box::pin(async move {
 						let provider:Arc<dyn StatusBarProvider> = run_time.Environment.Require();
-						let text = Parameters.get(0).and_then(Value::as_str).unwrap_or("status").to_string();
+
+						// The extension host serialises this as an object with named fields,
+						// matching the shape used by the RPC layer (EntryIdentifier = id).
+						let entry_id = Parameters
+							.get("id")
+							.and_then(Value::as_str)
+							.ok_or_else(|| "$statusBar:set: missing 'id' field".to_string())?;
+
+						let item_id = Parameters
+							.get("itemId")
+							.and_then(Value::as_str)
+							.unwrap_or(entry_id);
+
+						let ext_id = Parameters
+							.get("extensionId")
+							.and_then(Value::as_str)
+							.unwrap_or("");
+
+						let text = Parameters
+							.get("text")
+							.and_then(Value::as_str)
+							.unwrap_or("")
+							.to_string();
+
+						let tooltip = Parameters
+							.get("tooltip")
+							.cloned();
+
+						let command = Parameters
+							.get("command")
+							.cloned();
+
+						let color = Parameters
+							.get("color")
+							.cloned();
+
+						let background_color = Parameters
+							.get("backgroundColor")
+							.cloned();
+
+						let is_aligned_left = Parameters
+							.get("alignLeft")
+							.and_then(Value::as_bool)
+							.unwrap_or(false);
+
+						let priority = Parameters
+							.get("priority")
+							.cloned();
+
+						let accessibility = Parameters
+							.get("accessibilityInformation")
+							.cloned();
+
 						let entry = StatusBarEntryDTO {
-							EntryIdentifier:"id".to_string(),
-							ItemIdentifier:"item".to_string(),
-							ExtensionIdentifier:"ext".to_string(),
-							Name:None,
-							Text:text,
-							Tooltip:None,
-							HasTooltipProvider:false,
-							Command:None,
-							Color:None,
-							BackgroundColor:None,
-							IsAlignedLeft:false,
-							Priority:None,
-							AccessibilityInformation:None,
+							EntryIdentifier: entry_id.to_string(),
+							ItemIdentifier: item_id.to_string(),
+							ExtensionIdentifier: ext_id.to_string(),
+							Name: None,
+							Text: text,
+							Tooltip: tooltip,
+							HasTooltipProvider: false,
+							Command: command,
+							Color: color,
+							BackgroundColor: background_color,
+							IsAlignedLeft: is_aligned_left,
+							Priority: priority,
+							AccessibilityInformation: accessibility,
 						};
+
 						provider
 							.SetStatusBarEntry(entry)
 							.await
@@ -50,9 +103,17 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 				move |run_time:Arc<ApplicationRunTime>| -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send>> {
 					Box::pin(async move {
 						let provider:Arc<dyn StatusBarProvider> = run_time.Environment.Require();
-						let id = Parameters.get(0).and_then(Value::as_str).unwrap_or("id").to_string();
+
+						// Require a non-empty id — a missing id would silently target the
+						// wrong entry (previously fell back to the literal string "id").
+						let id = Parameters
+							.get(0)
+							.and_then(Value::as_str)
+							.filter(|s| !s.is_empty())
+							.ok_or_else(|| "$statusBar:dispose: missing or empty entry id".to_string())?;
+
 						provider
-							.DisposeStatusBarEntry(id)
+							.DisposeStatusBarEntry(id.to_string())
 							.await
 							.map(|_| json!(null))
 							.map_err(|e| e.to_string())
@@ -67,10 +128,21 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 				move |run_time:Arc<ApplicationRunTime>| -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send>> {
 					Box::pin(async move {
 						let provider:Arc<dyn StatusBarProvider> = run_time.Environment.Require();
-						let message_id = Parameters.get(0).and_then(Value::as_str).unwrap_or("msg_id").to_string();
-						let text = Parameters.get(1).and_then(Value::as_str).unwrap_or("message").to_string();
+
+						let message_id = Parameters
+							.get(0)
+							.and_then(Value::as_str)
+							.filter(|s| !s.is_empty())
+							.ok_or_else(|| "$setStatusBarMessage: missing or empty message id".to_string())?;
+
+						let text = Parameters
+							.get(1)
+							.and_then(Value::as_str)
+							.unwrap_or("")
+							.to_string();
+
 						provider
-							.SetStatusBarMessage(message_id, text)
+							.SetStatusBarMessage(message_id.to_string(), text)
 							.await
 							.map(|_| json!(null))
 							.map_err(|e| e.to_string())
@@ -85,9 +157,15 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 				move |run_time:Arc<ApplicationRunTime>| -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send>> {
 					Box::pin(async move {
 						let provider:Arc<dyn StatusBarProvider> = run_time.Environment.Require();
-						let message_id = Parameters.get(0).and_then(Value::as_str).unwrap_or("msg_id").to_string();
+
+						let message_id = Parameters
+							.get(0)
+							.and_then(Value::as_str)
+							.filter(|s| !s.is_empty())
+							.ok_or_else(|| "$disposeStatusBarMessage: missing or empty message id".to_string())?;
+
 						provider
-							.DisposeStatusBarMessage(message_id)
+							.DisposeStatusBarMessage(message_id.to_string())
 							.await
 							.map(|_| json!(null))
 							.map_err(|e| e.to_string())


### PR DESCRIPTION
## Summary

All four `$statusBar:*` handlers in `StatusBar.rs` used hardcoded sentinel strings for identifiers. This PR replaces them with real parameter reads, matching the shape that the VS Code extension host and the Cocoon RPC layer actually send.

---

## Problems fixed

### `$statusBar:set` — wrong identifiers on every call

The extension host serialises status bar entries as a named-field object, matching the `CreateStatusBarItem` / `SetStatusBarText` RPC shape where `EntryIdentifier = id` and `ExtensionIdentifier = String::new()`. The old handler read only `Parameters[0]` as `text` and hardcoded the rest:

```rust
// Before
let text = Parameters.get(0).and_then(Value::as_str).unwrap_or("status").to_string();
let entry = StatusBarEntryDTO {
    EntryIdentifier: "id".to_string(),   // ← always "id"
    ItemIdentifier:  "item".to_string(), // ← always "item"
    ExtensionIdentifier: "ext".to_string(), // ← always "ext"
    Text: text,
    ...
};
```

Every call to `$statusBar:set` registered a new entry under the fixed key `"id"`, clobbering any previously set entry and making it impossible for the provider to distinguish between items.

**After:** reads `id`, `itemId`, `extensionId`, `text`, `tooltip`, `command`, `color`, `backgroundColor`, `alignLeft`, `priority`, and `accessibilityInformation` from the Parameters object. `itemId` falls back to `id` (matching RPC behaviour); `extensionId` falls back to `""` (matching `String::new()` in the RPC layer).

### `$statusBar:dispose` — dispose always targeted `"id"`

```rust
// Before
let id = Parameters.get(0).and_then(Value::as_str).unwrap_or("id").to_string();
```

A missing or null first argument silently disposed the entry with identifier `"id"` — the same hardcoded key set by `$statusBar:set`. Any legitimate dispose from the extension host with a missing argument targeted the wrong (or non-existent) entry with no error surfaced.

**After:** returns `Err("$statusBar:dispose: missing or empty entry id")` when `Parameters[0]` is absent or empty. The RPC error propagates back through `MappedEffect` and is logged by `CreateEffectForRequest`.

### `$setStatusBarMessage` / `$disposeStatusBarMessage` — same pattern

Both used `.unwrap_or("msg_id")` for the message identifier. Same fix applied: `.filter(|s| !s.is_empty()).ok_or_else(|| ...)` so missing identifiers surface as errors.

The `text` argument to `$setStatusBarMessage` keeps `.unwrap_or("")` — an empty message string is valid (clears the status bar text).

---

## Files changed

| File | Change |
|---|---|
| `Source/Track/Effect/CreateEffectForRequest/StatusBar.rs` | Full parameter extraction for all four handlers; sentinel strings removed |