### PR TITLE
fix(UIQP): wire oneshot reply channel for all four dialog methods

### DIFF
--- a/Source/Track/Effect/CreateEffectForRequest/WindowUI.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/WindowUI.rs
@@ -1,14 +1,21 @@
 #![allow(non_snake_case, unused_variables, dead_code, unused_imports)]
 
-//! Window-namespace UI commands from Cocoon's window shim. These emit Tauri
-//! events to Sky and return immediately (no reply channel wired yet).
+//! Window-namespace UI commands from Cocoon's window shim.
+//! ShowMessage is fire-and-forget (no selection reply needed).
+//! ShowQuickPick / ShowInputBox / ShowOpenDialog / ShowSaveDialog block on
+//! a oneshot channel that is resolved by the frontend via ResolveUIRequest.
 
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use serde_json::{Value, json};
 use tauri::Runtime;
 
-use crate::{RunTime::ApplicationRunTime::ApplicationRunTime, Track::Effect::MappedEffectType::MappedEffect, dev_log};
+use crate::{
+	ApplicationState::State::ApplicationState::ApplicationState,
+	RunTime::ApplicationRunTime::ApplicationRunTime,
+	Track::Effect::MappedEffectType::MappedEffect,
+	dev_log,
+};
 
 pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Result<MappedEffect, String>> {
 	match MethodName {
@@ -64,7 +71,9 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 				move |run_time:Arc<ApplicationRunTime>| -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send>> {
 					Box::pin(async move {
 						use tauri::Emitter;
+
 						let Args = if Parameters.is_array() { Parameters } else { json!([Parameters]) };
+
 						let Channel = match MethodNameOwned.as_str() {
 							"Window.ShowQuickPick" => "sky://quickpick/show",
 							"Window.ShowInputBox" => "sky://input-box/show",
@@ -72,7 +81,7 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 							"Window.ShowSaveDialog" => "sky://dialog/save",
 							_ => "sky://quickpick/show",
 						};
-						let AppHandle = run_time.Environment.ApplicationHandle.clone();
+
 						let Nonce = format!(
 							"ui-{}",
 							std::time::SystemTime::now()
@@ -80,10 +89,36 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 								.map(|D| D.as_nanos())
 								.unwrap_or(0)
 						);
+
+						// Register the reply channel before emitting so the
+						// frontend can never race-resolve before we are waiting.
+						let (tx, rx) = tokio::sync::oneshot::channel();
+						run_time.ApplicationState.UI.AddPendingRequest(Nonce.clone(), tx);
+
+						let AppHandle = run_time.Environment.ApplicationHandle.clone();
 						if let Err(Error) = AppHandle.emit(Channel, json!({ "nonce": Nonce, "args": Args })) {
+							// Emit failed — remove the dangling sender so the map
+							// does not grow unboundedly on repeated failures.
+							run_time.ApplicationState.UI.RemovePendingRequest(&Nonce.clone());
 							dev_log!("ipc", "warn: [{}] {} emit failed: {}", MethodNameOwned, Channel, Error);
+							return Err(format!("[{}] emit failed: {}", MethodNameOwned, Error));
 						}
-						Ok(Value::Null)
+
+						// Block until the frontend calls ResolveUIRequest with
+						// the same nonce, or the sender is dropped (dialog
+						// dismissed / window closed).
+						match rx.await {
+							Ok(Ok(Value)) => Ok(Value),
+							Ok(Err(CommonError)) => Err(CommonError.to_string()),
+							Err(_RecvError) => {
+								// Sender was dropped without a reply — the user
+								// dismissed the dialog.  Return null so the extension
+								// host sees `undefined` (VS Code contract for cancelled
+								// quick-pick / input-box).
+								dev_log!("ipc", "[{}] dialog dismissed (nonce dropped)", MethodNameOwned);
+								Ok(Value::Null)
+							},
+						}
 					})
 				};
 


### PR DESCRIPTION
## Problem

`Window.ShowQuickPick`, `Window.ShowInputBox`, `Window.ShowOpenDialog`, and `Window.ShowSaveDialog` all emitted the Sky event and returned `Ok(Value::Null)` immediately — fire-and-forget. The extension host therefore always received `undefined` as the result, making every quick-pick, input-box, and file dialog non-functional from Cocoon's perspective.

## Root cause

The `PendingUserInterfaceRequest` infrastructure (`UIState`, `ResolveUIRequest`) was already in place but none of the four dialog effect handlers called `AddPendingRequest` or awaited the reply.

## Fix

In `Source/Track/Effect/CreateEffectForRequest/WindowUI.rs` each of the four methods now:

1. Creates a `tokio::sync::oneshot` channel `(tx, rx)`.
2. Registers `(nonce → tx)` via `ApplicationState.UI.AddPendingRequest` **before** emitting, eliminating any front-end resolve race.
3. Emits the Sky event with `{ nonce, args }` in the payload.
4. On emit failure: removes the dangling sender from the map and returns `Err`.
5. Awaits `rx`:
   - `Ok(Ok(value))` → returns the user selection to the extension host.
   - `Ok(Err(e))` → propagates `CommonError` as a string.
   - `Err(_)` (sender dropped, dialog dismissed) → returns `Ok(Value::Null)` matching VS Code's contract for a cancelled dialog.

`Window.ShowMessage` remains fire-and-forget (no reply needed).

## Checklist
- [x] `AddPendingRequest` called before `emit` (no resolve race)
- [x] Dangling sender cleaned up on emit failure
- [x] Dismiss/cancel path returns `null` (matches VS Code `undefined` contract)
- [x] `CommonError` → `String` mapping satisfies `MappedEffect` return type