### PR TITLE
fix(WSAE): propagate Err from applyEdit instead of synthetic true

### DIFF
--- a/Source/Track/Effect/CreateEffectForRequest/Workspace.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/Workspace.rs
@@ -23,23 +23,20 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 						} else {
 							Parameters
 						};
-						match crate::Environment::UserInterfaceProvider::SendUserInterfaceRequest(
+						crate::Environment::UserInterfaceProvider::SendUserInterfaceRequest(
 							&run_time.Environment,
 							"sky://workspace/applyEdit",
 							Payload,
 						)
 						.await
-						{
-							Ok(Value) => Ok(Value),
-							Err(Error) => {
-								dev_log!(
-									"ipc",
-									"warn: [applyEdit] Sky did not answer ({:?}); returning synthetic true",
-									Error
-								);
-								Ok(json!(true))
-							},
-						}
+						.map_err(|Error| {
+							dev_log!(
+								"ipc",
+								"error: [applyEdit] Sky did not answer ({:?})",
+								Error
+							);
+							Error.to_string()
+						})
 					})
 				};
 


### PR DESCRIPTION
## Problem

`applyEdit` was returning `Ok(json!(true))` when `sky://workspace/applyEdit` failed to respond. Any extension that checks the boolean result of `workspace.applyEdit(edit)` would believe the edit succeeded and proceed against post-apply state that never materialised — silently corrupting extension logic.

The comment in the original code even acknowledged this: *"returning synthetic true"*.

## Fix

Remove the `match` fallback entirely and let `.map_err(...)` propagate the failure as an `Err`. The `dev_log!` call is preserved (upgraded from `warn` to `error` severity) so the failure is still observable in logs, but now the extension host also surfaces it correctly.

## Comparison with `showTextDocument`

`showTextDocument` in the same file uses `Ok(json!(null))` on its fallback path, which is safer than `true` for a boolean-checked result but still swallows the error. This PR goes one step further for `applyEdit` — returning a real `Err` — because the consequence of a silent false-positive here is post-apply state corruption, not just a missing editor reference.

## Batch
`WSAE` — second of three fix PRs from the post-merge inspection.