### PR TITLE
fix(GITEX): wrap git subprocess with a 30s timeout

### DIFF
--- a/Source/Track/Effect/CreateEffectForRequest/Git.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/Git.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case, unused_variables, dead_code, unused_imports)]
 
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 
 use serde_json::{Value, json};
 use tauri::Runtime;
@@ -65,15 +65,25 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 							Cwd.display()
 						);
 						let StartAt = std::time::Instant::now();
-						let Output = tokio::process::Command::new("git")
-							.args(&Args)
-							.current_dir(&Cwd)
-							.output()
-							.await
-							.map_err(|Error| format!("$gitExec failed to spawn git: {}", Error))?;
-						let ExitCode = Output.status.code().unwrap_or(-1);
-						let Stdout = String::from_utf8_lossy(&Output.stdout).to_string();
-						let Stderr = String::from_utf8_lossy(&Output.stderr).to_string();
+						let OutputResult = tokio::time::timeout(
+							Duration::from_secs(30),
+							tokio::process::Command::new("git")
+								.args(&Args)
+								.current_dir(&Cwd)
+								.output(),
+						)
+						.await
+						.map_err(|_| {
+							format!(
+								"$gitExec timed out after 30s: args={:?} cwd={}",
+								Args,
+								Cwd.display()
+							)
+						})?
+						.map_err(|Error| format!("$gitExec failed to spawn git: {}", Error))?;
+						let ExitCode = OutputResult.status.code().unwrap_or(-1);
+						let Stdout = String::from_utf8_lossy(&OutputResult.stdout).to_string();
+						let Stderr = String::from_utf8_lossy(&OutputResult.stderr).to_string();
 						dev_log!(
 							"grpc",
 


### PR DESCRIPTION
## Problem

`$gitExec` spawned `tokio::process::Command::new("git").output().await` with no timeout and no cancellation boundary. A slow or hanging git operation — large repo, network-mounted filesystem, credential prompt, or a locked index — would hold the effect slot open indefinitely, with no way for the runtime to recover short of a full restart.

The `dev_log!` after the call recorded elapsed time, but only after the fact — it could not interrupt a hung process.

## Fix

Wrap the `output()` call with `tokio::time::timeout(Duration::from_secs(30), ...)`. On expiry:
- The future is dropped (child process abandoned)
- A descriptive `Err` is returned including `args` and `cwd` so the hang is diagnosable in logs
- The extension host receives a proper error it can surface to the user

The 30s ceiling is generous enough for legitimate slow operations over gRPC but tight enough to prevent indefinite hangs. The elapsed `dev_log!` is preserved so timing is still observable on the happy path.

## Changes
- Added `use std::time::Duration`
- Replaced bare `.output().await` with `tokio::time::timeout(Duration::from_secs(30), ...).await.map_err(...)?.map_err(...)?`
- Renamed `Output` → `OutputResult` to reflect it is now the inner unwrapped value after timeout and spawn error handling

## Batch
`GITEX` — third and final fix PR from the post-merge inspection.