### PR TITLE
fix(LNGA): release scanned_extensions lock before aggregation loop

### DIFF
--- a/Source/Track/Effect/CreateEffectForRequest/Languages.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/Languages.rs
@@ -20,15 +20,19 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 							.ScannedExtensions
 							.ScannedExtensions
 							.clone();
-						let Guard = match scanned.lock() {
-							Ok(g) => g,
-							Err(error) => {
-								return Err(format!("Languages.GetAll: scanned-extensions lock poisoned: {}", error));
-							},
+
+						let Snapshot = {
+							let Guard = match scanned.lock() {
+								Ok(g) => g,
+								Err(error) => {
+									return Err(format!("Languages.GetAll: scanned-extensions lock poisoned: {}", error));
+								},
+							};
+							Guard.clone()
 						};
 
 						let mut merged:HashMap<String, serde_json::Map<String, Value>> = HashMap::new();
-						for Dto in Guard.values() {
+						for Dto in Snapshot.values() {
 							let Contributes = match Dto.Contributes.as_ref() {
 								Some(c) => c,
 								None => continue,
@@ -77,7 +81,6 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 								}
 							}
 						}
-						drop(Guard);
 
 						let result:Vec<Value> = merged.into_values().map(Value::Object).collect();
 						dev_log!("ipc", "[Languages.GetAll] returning {} languages", result.len());


### PR DESCRIPTION
## LNGA - Languages.rs lock held for full aggregation loop

**Defect:** `Languages.GetAll` locked `scanned_extensions` and held the mutex for the entire multi-extension aggregation loop. Any other thread needing the same lock was blocked for the full duration of the merge.

**Fix:** Clone the map inside a short block scope immediately after acquiring the lock, letting the guard drop at the end of that block. The aggregation then runs entirely on the owned clone with no lock held.

```rust
let Snapshot = {
    let Guard = match scanned.lock() { ... };
    Guard.clone()
};
// lock released here, aggregate over Snapshot
```

The explicit `drop(Guard)` at the end of the original function is removed because the guard now drops automatically at the end of the inner block.

**Files changed:** `Source/Track/Effect/CreateEffectForRequest/Languages.rs`