### PR TITLE
docs(mod): update LanguageFeatures table entry to reflect LNGF fix

### DIFF
--- a/Source/Track/Effect/CreateEffectForRequest/mod.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/mod.rs
@@ -21,7 +21,7 @@
 //! | FileSystem        | `FileSystem.*`, `FileWatcher.*`, `openDocument` aliases  |
 //! | Git               | `$gitExec`                                               |
 //! | Keybinding        | `Keybinding.GetResolved`                                 |
-//! | LanguageFeatures  | `$languageFeatures:registerProvider`                     |
+//! | LanguageFeatures  | `register_*_provider` (one arm per provider type)        |
 //! | Languages         | `Languages.GetAll`                                       |
 //! | NativeHost        | `NativeHost.OpenExternal`                                |
 //! | SCM               | `$scm:*`                                                 |


### PR DESCRIPTION
## What

The doc-comment table in `mod.rs` line 22 still described the old
single catch-all arm `$languageFeatures:registerProvider`. After the
LNGF fix (PR #56) the module now dispatches on individual
`register_*_provider` method names, one match arm per provider type.
This PR updates the table entry to match reality.

## Why

Stale doc-comments mislead the next reader of the routing table into
thinking the old hardcoded-Hover dispatch is still in place.

## Change

`mod.rs` table row only - one line, no code or logic change.