### PR TITLE
fix: resolve 4 compile errors in CreateEffectForRequest

### DIFF
--- a/Source/Track/Effect/CreateEffectForRequest/StatusBar.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/StatusBar.rs
@@ -65,7 +65,7 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 
 						let priority = Parameters
 							.get("priority")
-							.cloned();
+							.and_then(Value::as_f64);
 
 						let accessibility = Parameters
 							.get("accessibilityInformation")

--- a/Source/Track/Effect/CreateEffectForRequest/UserInterface.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/UserInterface.rs
@@ -46,7 +46,10 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 							.get(0)
 							.and_then(Value::as_array)
 							.cloned()
-							.unwrap_or_default();
+							.unwrap_or_default()
+							.into_iter()
+							.filter_map(|v| serde_json::from_value::<CommonLibrary::UserInterface::DTO::QuickPickItemDTO::QuickPickItemDTO>(v).ok())
+							.collect::<Vec<_>>();
 						let options = Parameters
 							.get(1)
 							.and_then(|V| {

--- a/Source/Track/Effect/CreateEffectForRequest/WindowUI.rs
+++ b/Source/Track/Effect/CreateEffectForRequest/WindowUI.rs
@@ -93,13 +93,13 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 						// Register the reply channel before emitting so the
 						// frontend can never race-resolve before we are waiting.
 						let (tx, rx) = tokio::sync::oneshot::channel();
-						run_time.ApplicationState.UI.AddPendingRequest(Nonce.clone(), tx);
+						run_time.Environment.ApplicationState.UI.AddPendingRequest(Nonce.clone(), tx);
 
 						let AppHandle = run_time.Environment.ApplicationHandle.clone();
 						if let Err(Error) = AppHandle.emit(Channel, json!({ "nonce": Nonce, "args": Args })) {
-							// Emit failed — remove the dangling sender so the map
+							// Emit failed -- remove the dangling sender so the map
 							// does not grow unboundedly on repeated failures.
-							run_time.ApplicationState.UI.RemovePendingRequest(&Nonce.clone());
+							run_time.Environment.ApplicationState.UI.RemovePendingRequest(&Nonce.clone());
 							dev_log!("ipc", "warn: [{}] {} emit failed: {}", MethodNameOwned, Channel, Error);
 							return Err(format!("[{}] emit failed: {}", MethodNameOwned, Error));
 						}
@@ -111,7 +111,7 @@ pub fn CreateEffect<R:Runtime>(MethodName:&str, Parameters:Value) -> Option<Resu
 							Ok(Ok(Value)) => Ok(Value),
 							Ok(Err(CommonError)) => Err(CommonError.to_string()),
 							Err(_RecvError) => {
-								// Sender was dropped without a reply — the user
+								// Sender was dropped without a reply -- the user
 								// dismissed the dialog.  Return null so the extension
 								// host sees `undefined` (VS Code contract for cancelled
 								// quick-pick / input-box).


### PR DESCRIPTION
Fixes 4 errors from E0308 and E0609:

- `StatusBar.rs`: `priority` extracted with `.and_then(Value::as_f64)` instead of `.cloned()`, yielding `Option<f64>` not `Option<Value>`
- `UserInterface.rs`: `items` deserialized via `serde_json::from_value::<QuickPickItemDTO>` so `ShowQuickPick` receives `Vec<QuickPickItemDTO>`
- `WindowUI.rs` (x2): `run_time.ApplicationState` -> `run_time.Environment.ApplicationState`